### PR TITLE
Fixing eservices filters and probingData parsing response

### DIFF
--- a/packages/models/src/eservice/eservice.ts
+++ b/packages/models/src/eservice/eservice.ts
@@ -194,9 +194,15 @@ export type EServiceMainData = z.infer<typeof EServiceMainData>;
 export const EServiceProbingData = z.object({
   probingEnabled: z.boolean(),
   state: EserviceInteropState,
-  responseReceived: z.date().transform((date) => date.toISOString()),
-  lastRequest: z.date().transform((date) => date.toISOString()),
-  responseStatus: EserviceStatus,
+  responseReceived: z
+    .date()
+    .transform((date) => date.toISOString())
+    .nullish(),
+  lastRequest: z
+    .date()
+    .transform((date) => date.toISOString())
+    .nullish(),
+  responseStatus: EserviceStatus.nullish(),
   pollingFrequency: z.number().int(),
 });
 export type EServiceProbingData = z.infer<typeof EServiceProbingData>;

--- a/packages/probing-api/src/utilities/enumUtils.ts
+++ b/packages/probing-api/src/utilities/enumUtils.ts
@@ -112,8 +112,10 @@ export function isBeenToLongRequest(
     return false;
   }
 
-  const timeDifferenceMinutes: number = (new Date().getTime() - new Date(lastRequest).getTime()) / (1000 * 60);
-  const toleranceThreshold: number = pollingFrequency * toleranceMultiplierInMinutes;
+  const timeDifferenceMinutes: number =
+    (new Date().getTime() - new Date(lastRequest).getTime()) / (1000 * 60);
+  const toleranceThreshold: number =
+    pollingFrequency * toleranceMultiplierInMinutes;
 
   return timeDifferenceMinutes > toleranceThreshold;
 }

--- a/packages/probing-api/src/utilities/enumUtils.ts
+++ b/packages/probing-api/src/utilities/enumUtils.ts
@@ -38,10 +38,10 @@ function handleState({
 }: {
   state: EserviceInteropState;
   probingEnabled: boolean;
-  lastRequest?: string;
-  responseReceived?: string;
   pollingFrequency: number;
-  responseStatus?: EserviceStatus | undefined;
+  lastRequest?: string | null;
+  responseReceived?: string | null;
+  responseStatus?: EserviceStatus | null;
 }): EserviceMonitorState {
   switch (state) {
     case eserviceInteropState.active:
@@ -75,8 +75,8 @@ export function isActive(viewState: EserviceInteropState): boolean {
 
 export function checkND(
   probingEnabled: boolean,
-  responseReceived: string | undefined,
-  lastRequest: string | undefined,
+  responseReceived: string | null | undefined,
+  lastRequest: string | null | undefined,
   pollingFrequency: number,
 ): boolean {
   return (
@@ -92,15 +92,17 @@ export function checkND(
   );
 }
 
-export function checkOFFLINE(status: EserviceStatus | undefined): boolean {
+export function checkOFFLINE(
+  status: EserviceStatus | null | undefined,
+): boolean {
   return status === responseStatus.ko;
 }
 
 export function isResponseReceivedBeforeLastRequest(
-  responseReceived: string | undefined,
-  lastRequest: string,
+  responseReceived: string | null | undefined,
+  lastRequest: string | null | undefined,
 ): boolean {
-  if (!responseReceived) {
+  if (!responseReceived || !lastRequest) {
     return false;
   }
 

--- a/packages/probing-api/src/utilities/enumUtils.ts
+++ b/packages/probing-api/src/utilities/enumUtils.ts
@@ -10,12 +10,6 @@ import {
 } from "pagopa-interop-probing-models";
 import { config } from "./config.js";
 
-const isBefore = (responseReceived: string, lastRequest: string): boolean =>
-  new Date(responseReceived).getTime() < new Date(lastRequest).getTime();
-
-const minutesDifferenceFromCurrentDate = (lastRequest: string): number =>
-  (new Date().getTime() - new Date(lastRequest).getTime()) / (1000 * 60);
-
 export function fromECToMonitorState(
   data: EServiceContent,
 ): EserviceMonitorState {
@@ -106,7 +100,7 @@ export function isResponseReceivedBeforeLastRequest(
     return false;
   }
 
-  return isBefore(responseReceived, lastRequest);
+  return new Date(responseReceived).getTime() < new Date(lastRequest).getTime();
 }
 
 export function isBeenToLongRequest(
@@ -118,8 +112,8 @@ export function isBeenToLongRequest(
     return false;
   }
 
-  const timeDifferenceMinutes = minutesDifferenceFromCurrentDate(lastRequest);
-  const toleranceThreshold = pollingFrequency * toleranceMultiplierInMinutes;
+  const timeDifferenceMinutes: number = (new Date().getTime() - new Date(lastRequest).getTime()) / (1000 * 60);
+  const toleranceThreshold: number = pollingFrequency * toleranceMultiplierInMinutes;
 
   return timeDifferenceMinutes > toleranceThreshold;
 }

--- a/packages/probing-eservice-operations/open-api/api-eservice-operations-interop-v1.yaml
+++ b/packages/probing-eservice-operations/open-api/api-eservice-operations-interop-v1.yaml
@@ -1011,9 +1011,6 @@ components:
       required: 
         - probingEnabled
         - state
-        - responseReceived
-        - lastRequest
-        - responseStatus
         - pollingFrequency
       properties:
         probingEnabled:
@@ -1025,13 +1022,17 @@ components:
           title: last response date
           type: string
           format: date-time
+          nullable: true
         lastRequest:
           title: last request date
           type: string
           format: date-time
+          nullable: true
         responseStatus:
           title: eservice last status
-          $ref: "#/components/schemas/EserviceStatus"
+          allOf:
+            - $ref: "#/components/schemas/EserviceStatus"
+          nullable: true
         pollingFrequency:
           title: eservice polling frequency
           type: integer


### PR DESCRIPTION
Updated the ProbingDataEserviceResponse schema to allow the lastRequest, responseReceived, and responseStatus fields to be optional and nullable.

This fixes the parsing error in GET /eservices/probingData/{eserviceRecordId} for an e-service that wasn't updated with the probing process data.

Corrected GET /eservices handling for N/D state